### PR TITLE
Multiple directories and cleanup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ grunt.initConfig({
         files: 'content/',
         indent: 4,
         minify:true,
-        append:'.min'
+        append:'.min',
+        cleanup:true
       },
    }
 });
@@ -48,10 +49,10 @@ grunt.registerTask('default', ['json-pretty']);
 ### Options
 
 #### files
-Type: `String`
+Type: `String` | `Array`
 Default value: `content/`
 
-A reference to a directory that contains JSON files.
+A reference to a directory or directories that contains JSON files.
 
 #### indent
 Type: `Number`
@@ -71,12 +72,21 @@ Default value: `'.min'`
 
 Append to minified version of each JSON file.
 
+#### cleanup
+Type: `Boolean`
+Default value: `false`
+
+Removes each original JSON file after minification.
+
+
+
 ## Release History
+* 0.2.0: Added support for multiple directories and file cleanup.
 * 0.1.9: fix default minify JSON.
 * 0.1.8: add dev dependencies.
 * 0.1.7: add release history notes to documentation.
 * 0.1.6: small adjustments.
-* 0.1.5 add the ability change appened string on minified JSON files.
+* 0.1.5  add the ability change appened string on minified JSON files.
 * 0.1.4: display output for successful and failed files.
 * 0.1.3: updates to documentation.
 * 0.1.2: updates to documentation.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ grunt.loadNpmTasks('grunt-json-pretty');
 grunt.registerTask('default', ['json-pretty']);
 ```
 
-### Example config with mutitple directories
+### Example config with multiple directories
 
 ```js
 grunt.initConfig({

--- a/README.md
+++ b/README.md
@@ -46,13 +46,38 @@ grunt.initConfig({
 grunt.loadNpmTasks('grunt-json-pretty');
 grunt.registerTask('default', ['json-pretty']);
 ```
+
+### Example config with mutitple directories
+
+```js
+grunt.initConfig({
+  'json-pretty': {
+      options: {
+        src: ['contentA/', 'contentB/','contentB/contentA/'],
+        indent: 4,
+        minify:true,
+        append:'.min',
+        cleanup:true
+      },
+   }
+});
+
+grunt.loadNpmTasks('grunt-json-pretty');
+grunt.registerTask('default', ['json-pretty']);
+```
+
 ### Options
 
 #### files
-Type: `String` | `Array`
+Type: `String`
 Default value: `content/`
 
-A reference to a directory or directories that contains JSON files.
+A reference to a directory that contains JSON files.
+
+#### src
+Type: `Array`
+
+A reference to multiple directories that contains JSON files.
 
 #### indent
 Type: `Number`

--- a/tasks/jsonpretty.js
+++ b/tasks/jsonpretty.js
@@ -5,63 +5,65 @@
  * Copyright (c) 2014 Ryan Burgess
  * Licensed under the MIT license.
  */
-
 'use strict';
 
-module.exports = function (grunt) {
-  grunt.registerTask('json-pretty', function(){
-    var fs = require('fs'),
-      options,
-      fileContent,
-      fileFull,
-      content,
-      minFile,
-      minContent,
-      minFileContent,
-      indent,
-      successful = 0,
-      failed = 0;
+module.exports = function(grunt) {
+    grunt.registerTask('json-pretty', function() {
+        var fs = require('fs'),
+            options,
+            directories = [],
+            json,
+            successful = 0,
+            failed = 0;
 
-    options = this.options({
-      indent: 2,
-      files: '/content/',
-      minify: false,
-      append: '.min'
-    });
+        options = this.options({
+            indent: 2,
+            files: '/content/',
+            minify: false,
+            append: '.min'
+        });
 
-    // Get list of files depending on the file directory
-    grunt.file.expand({
-      filter: 'isFile',
-        cwd: options.files // Change this reference to your directory
-      }, 
-      ['**/*.json']).forEach(function(file){
+        //set directory(ies)
+        if (Array.isArray(options.src || options.files)) directories = options.src || options.files;
+        else directories.push(options.src || options.files);
 
-        try {
-          fileFull = options.files + file;
-          fileContent = fs.readFileSync(fileFull);
-          content = JSON.parse(fileContent);
-          successful++;
+        //prettify function
+        function pretty(directory) {
+            return function(file) {
+                try {
+                   //set file
+                    file = directory + file;
+                    //read the file and parse
+                    json = JSON.parse(fs.readFileSync(file));
+                    successful++;
 
-          //Serialize as JSON and Write it to a file
-          fs.writeFileSync(fileFull, JSON.stringify(content, false, options.indent));
-          if(options.minify !== false){
-        
-            if(fileFull.indexOf(options.append+'.json') > -1){
-              minContent = fs.readFileSync(minFile);
-            }else{
-              minFile = fileFull.replace('.json', options.append+'.json');
-              minContent = fs.readFileSync(fileFull);
+                    //Serialize as JSON and Write it to a file
+                    fs.writeFileSync(file, JSON.stringify(json, false, options.indent));
+                    if (options.minify === true) {
+                      //set the file
+                      file = file.indexOf(options.append + '.json') > -1 ? file : file.replace('.json', options.append + '.json');
+                      //read file and parse
+                      json = JSON.parse(fs.readFileSync(file));
+                      //write the minified file
+                      fs.writeFileSync(file, JSON.stringify(json));
+                    }
+                } catch (e) {
+                    failed++;
+                    grunt.log.error('File "' + file + '" failed JSON pretty.');
+                    grunt.fail.warn(e);
+                }
             }
-            minFileContent = JSON.parse(minContent);
-            fs.writeFileSync(minFile, JSON.stringify(minFileContent));
-          }
-        }catch (e) {
-          failed++;
-          grunt.log.error('File "' + file + '" failed JSON pretty.');
-          grunt.fail.warn(e);
         }
+
+        directories.forEach(function(directory) {
+          //maybe a directory doesn't have a '/' ?
+          directory = directory.slice(-1) === '/' ? directory : directory + "/";
+            // Get list of files depending on the file directory
+            grunt.file.expand({
+                filter: 'isFile',
+                cwd: directory // Change this reference to your directory
+            }, ['**/*.json']).forEach(pretty(directory));
+        })
+        grunt.log.ok(successful + ' file' + (successful === 1 ? '' : 's') + ' JSON files prettified.');
     });
-    // output files updated
-    grunt.log.ok(successful + ' file' + (successful === 1 ? '' : 's') + ' JSON files updated.');
-  });
 };

--- a/tasks/jsonpretty.js
+++ b/tasks/jsonpretty.js
@@ -25,8 +25,10 @@ module.exports = function(grunt) {
         });
 
         //set directory(ies)
-        if (Array.isArray(options.src || options.files)) directories = options.src || options.files;
-        else directories.push(options.src || options.files);
+        if (Array.isArray(options.src)) directories = options.src;
+        //just in case options.src can be a string
+        else if (typeof options.src == 'string' || options.src instanceof String) directories.push(options.src);
+        else directories.push(options.files);
 
         //prettify & minify function
         function pretty(directory) {


### PR DESCRIPTION
Hi, this pull request adds multiple directories and cleanup support. You can now use an array of directories and prettify or minify the JSON files like so:

``` js
grunt.initConfig({
    'json-pretty': {
            options: {
               //`files` works as well (for a single directory only)
                src: ['pet/cat/meow/', 'pet/dog/bark/' /*...*/],
                indent: 4,
                minify: true,
                append: '.min'
            },
        }
});
```

Also, a new cleanup option has been added. Appending the `cleanup` option with a value of `true` to the example above, will remove the un-minified JSON files in the same directory where they were minified.
